### PR TITLE
require-date

### DIFF
--- a/shutterstock-ruby.gemspec
+++ b/shutterstock-ruby.gemspec
@@ -1,5 +1,6 @@
 # -*- encoding: utf-8 -*-
 $:.push File.expand_path('../lib', __FILE__)
+require 'date'
 
 Gem::Specification.new do |s|
   s.name        = 'shutterstock-ruby'


### PR DESCRIPTION
Was causing the following:
```
  /opt/rubies/ruby-2.3.4/lib/ruby/gems/2.3.0/gems/bundler-1.15.0/lib/bundler.rb:489:in `rescue in eval_gemspec':  (Bundler::GemspecError)
  [!] There was an error while loading `shutterstock-ruby.gemspec`: uninitialized constant Date
  Did you mean?  Data. Bundler cannot continue.

   #  from /opt/rubies/ruby-2.3.4/lib/ruby/gems/2.3.0/bundler/gems/shutterstock-ruby-17972c5d4add/shutterstock-ruby.gemspec:8
   #  -------------------------------------------
   #    s.platform    = Gem::Platform::RUBY
   >    s.date        = Date.today.to_s
   #    s.summary     = "An API wrapper for the Shutterstock API's"
   #  -------------------------------------------
  	from /opt/rubies/ruby-2.3.4/lib/ruby/gems/2.3.0/gems/bundler-1.15.0/lib/bundler.rb:481:in `eval_gemspec'
  	from /opt/rubies/ruby-2.3.4/lib/ruby/gems/2.3.0/gems/bundler-1.15.0/lib/bundler.rb:423:in `block in load_gemspec_uncached'
  	from /opt/rubies/ruby-2.3.4/lib/ruby/gems/2.3.0/gems/bundler-1.15.0/lib/bundler/shared_helpers.rb:55:in `chdir'
  	from /opt/rubies/ruby-2.3.4/lib/ruby/gems/2.3.0/gems/bundler-1.15.0/lib/bundler/shared_helpers.rb:55:in `block in chdir'
  	from /opt/rubies/ruby-2.3.4/lib/ruby/2.3.0/monitor.rb:214:in `mon_synchronize'
  	from /opt/rubies/ruby-2.3.4/lib/ruby/gems/2.3.0/gems/bundler-1.15.0/lib/bundler/shared_helpers.rb:54:in `chdir'
  	from /opt/rubies/ruby-2.3.4/lib/ruby/gems/2.3.0/gems/bundler-1.15.0/lib/bundler.rb:422:in `load_gemspec_uncached'
  	from /opt/rubies/ruby-2.3.4/lib/ruby/gems/2.3.0/gems/bundler-1.15.0/lib/bundler.rb:408:in `load_gemspec'
  	from /opt/rubies/ruby-2.3.4/lib/ruby/gems/2.3.0/gems/bundler-1.15.0/lib/bundler/source/git.rb:243:in `block in serialize_gemspecs_in'
  	from /opt/rubies/ruby-2.3.4/lib/ruby/gems/2.3.0/gems/bundler-1.15.0/lib/bundler/source/git.rb:239:in `each'
  	from /opt/rubies/ruby-2.3.4/lib/ruby/gems/2.3.0/gems/bundler-1.15.0/lib/bundler/source/git.rb:239:in `serialize_gemspecs_in'
  	from /opt/rubies/ruby-2.3.4/lib/ruby/gems/2.3.0/gems/bundler-1.15.0/lib/bundler/source/git.rb:162:in `specs'
  	from /opt/rubies/ruby-2.3.4/lib/ruby/gems/2.3.0/gems/bundler-1.15.0/lib/bundler/lazy_specification.rb:75:in `__materialize__'
  	from /opt/rubies/ruby-2.3.4/lib/ruby/gems/2.3.0/gems/bundler-1.15.0/lib/bundler/spec_set.rb:84:in `block in materialize'
  	from /opt/rubies/ruby-2.3.4/lib/ruby/gems/2.3.0/gems/bundler-1.15.0/lib/bundler/spec_set.rb:81:in `map!'
  	from /opt/rubies/ruby-2.3.4/lib/ruby/gems/2.3.0/gems/bundler-1.15.0/lib/bundler/spec_set.rb:81:in `materialize'
  	from /opt/rubies/ruby-2.3.4/lib/ruby/gems/2.3.0/gems/bundler-1.15.0/lib/bundler/definition.rb:159:in `specs'
  	from /opt/rubies/ruby-2.3.4/lib/ruby/gems/2.3.0/gems/bundler-1.15.0/lib/bundler/definition.rb:140:in `resolve_with_cache!'
  	from /opt/elasticbeanstalk/support/scripts/check-for-gem.rb:22:in `<main>'
```