### PR TITLE
Allow purchase metadata

### DIFF
--- a/lib/shutterstock-ruby/videos.rb
+++ b/lib/shutterstock-ruby/videos.rb
@@ -23,6 +23,10 @@ module ShutterstockRuby
       JSON.parse(get("/videos/licenses", params.merge(options)))
     end
 
+    def download(licence)
+      JSON.parse(post("/videos/licenses/#{licence}/downloads", {}.to_json))
+    end
+
     class << self
       def search(query, options = {})
         client.search(query, options)

--- a/lib/shutterstock-ruby/videos.rb
+++ b/lib/shutterstock-ruby/videos.rb
@@ -12,8 +12,15 @@ module ShutterstockRuby
 
     def purchase(id, subscription_id, size, options = {})
       params = { subscription_id: subscription_id, size: size }
-      body = { videos: [ video_id: id ] }.to_json
+      metadata = options.delete(:metadata) || {}
+
+      body = { videos: [ { video_id: id }.merge(metadata)] }.to_json
       JSON.parse(post("/videos/licenses", body, params, options))
+    end
+
+    def licenses(video_id, license, options = {})
+      params = { video_id: video_id, license: license }
+      JSON.parse(get("/videos/licenses", params.merge(options)))
     end
 
     class << self

--- a/shutterstock-ruby.gemspec
+++ b/shutterstock-ruby.gemspec
@@ -4,7 +4,7 @@ require 'date'
 
 Gem::Specification.new do |s|
   s.name        = 'shutterstock-ruby'
-  s.version     = '0.4.0'
+  s.version     = '0.4.1'
   s.platform    = Gem::Platform::RUBY
   s.date        = Date.today.to_s
   s.summary     = "An API wrapper for the Shutterstock API's"


### PR DESCRIPTION
* Allows you to check if a video has been purchased already and to get the download url for it
* Allows you to send through metadata when purchasing a video

Replaces https://github.com/Biteable/shutterstock-ruby/pull/4 and https://github.com/Biteable/shutterstock-ruby/pull/5

If this gets the ok ill close this PR and open an upstream one